### PR TITLE
fix the ics invite

### DIFF
--- a/src/Resources/views/drink/invite_ics.twig
+++ b/src/Resources/views/drink/invite_ics.twig
@@ -9,8 +9,7 @@ STATUS:TENTATIVE
 DTSTART;VALUE=DATE-TIME:{{ datetimes.start }} 
 TRANSP:TRANSPARENT
 DTSTAMP:{{ datetimes.current }} 
-ATTENDEE;CUTYPE=3DINDIVIDUAL;ROLE=3DREQ-PARTICIPANT;PARTSTAT=3DNEEDS-ACTION;RSV
- P=3DTRUE;X-NUM-GUESTS=3D0;CN={{ user.lastname }} {{ user.firstname }}:MAILTO:{{ user.email }}
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;X-NUM-GUESTS=0;CN={{ user.lastname }} {{ user.firstname }}:MAILTO:{{ user.email }}
 UID:{{ datetimes.current }}-aperophp.net
 SUMMARY:Apéro PHP
 ORGANIZER;CN=aperophp.net:MAILTO:noreply@aperophp.net


### PR DESCRIPTION
The invite wasn't working because the attendee line was
already quoted in the twig template, so it was double
quoted by the swiftmailer's quoted-printable option.

Before :
![before](https://f.cloud.github.com/assets/320372/463643/3cdb30ce-b586-11e2-86f1-81e4630e0366.png)

After :
![after](https://f.cloud.github.com/assets/320372/463644/41b37e76-b586-11e2-93ed-9cd837d982c4.png)
