### PR TITLE
correction nom de la clef license dans le composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name"              : "afup/aperophp",
     "description"       : "Source code for aperophp.net website",
-    "licence"           : "GPL-3.0+",
+    "license"           : "GPL-3.0+",
     "minimum-stability" : "dev",
     "require": {
         "silex/silex"               : "1.0.*",


### PR DESCRIPTION
Message apparaissant en lançant la commande php composer.phar validate:

```
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See http://getcomposer.org/doc/04-schema.md for details on the schema
The property licence is not defined and the definition does not allow additional properties
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
```

La clef devrait être "license" au lieu de "licence".

Après correctif : 
```
./composer.json is valid
```

cf #114 et #116