### PR TITLE
correction lancement tests sur travis

### DIFF
--- a/app/config_travis.php
+++ b/app/config_travis.php
@@ -1,5 +1,9 @@
 <?php
 $app['db.options'] = array(
-    'user'     => 'root',
-    'password' => '',
+    'driver'    => $app['db.options']['driver'],
+    'host'      => $app['db.options']['host'],
+    'dbname'    => $app['db.options']['dbname'],
+    'user'      => 'root',
+    'password'  => '',
 );
+


### PR DESCRIPTION
La clef db.options était complètement écrasée au lieu d'écraser
seulement les clefs user et password de db.options.

On tombait donc sur une notice :

```
PHP Notice: Undefined index: dbname in
/home/travis/build/afup/aperophp/app/config_test.php on line 10
```

Lors du

```
$ php app/console db:install --test --load-fixtures
```
