### PR TITLE
Modification premier jour affiché sur calendrier de création d'apéro

### DIFF
--- a/web/js/datepicker.js
+++ b/web/js/datepicker.js
@@ -4,6 +4,7 @@
 function init_datepicker(inputDP, altInputDP) 
 {
 	inputDP.datepicker({ 
+		firstDay: 1,
 		dateFormat: 'dd/mm/yy', 
 		altField: altInputDP, 
 		altFormat: 'yy-mm-dd',


### PR DESCRIPTION
Le premier jour affiché dans le calendrer s'affichant au clic sur la
date de l'apéro du formulaire de création était un dimanche.

Ce premier jour est maintenant un lundi.

cf #128