### PR TITLE
ajout support des twitters cards sur pages d'apéro

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -78,6 +78,7 @@ $app->register(new TwigServiceProvider(), array(
 // Add Twig extensions
 $app['twig'] = $app->share($app->extend('twig', function($twig, $app) {
     $twig->addExtension(new Twig_Extensions_Extension_Debug());
+    $twig->addExtension(new Twig_Extensions_Extension_Text());
 
     return $twig;
 }));

--- a/src/Resources/views/drink/view.html.twig
+++ b/src/Resources/views/drink/view.html.twig
@@ -1,5 +1,13 @@
 {% extends "layout.html.twig" %}
 
+{% block metas %}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="{{ drink.kind|trans }} PHP - {{ drink.city_name }} - {{ drink.day|date("d") }} {{ drink.day|date("F")|trans|lower }} {{ drink.hour|date("H:i") }}">
+<meta name="twitter:description" content="{{ drink.description|striptags|replace({"\n": " "})|truncate(200)|raw }}">
+<meta name="twitter:image:src" content="{{ app.request.schemeAndHttpHost }}/img/aperophp.gif">
+<meta name="twitter:domain" content="aperoPHP.net">
+{% endblock%}
+
 {% block content %}
 <div class="span8">
     <div class="widget">

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Ap&eacute;ro PHP</title>
     <meta name="viewport" content="initial-scale=1.0">
+    {% block metas %}{% endblock %}
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
En intégrant ces balises meta, les twitts content un lien vers la page d'apéro ressembleraient à ceci : 

![twittercard](https://f.cloud.github.com/assets/320372/1320779/befb0cce-337a-11e3-9367-1787d205633a.png)
