### PR TITLE
Correction du fichier après l'issue 122

### DIFF
--- a/bin/assets.sh
+++ b/bin/assets.sh
@@ -4,7 +4,7 @@
 #
 SCRIPTDIR=$(cd $(dirname "$0"); pwd)
 MAINDIR=$(cd $(dirname "$DIR"); pwd)
-BOOTSTRAPDIR=$MAINDIR/vendor/twitter/bootstrap
+BOOTSTRAPDIR=$MAINDIR/vendor/twbs/bootstrap
 [ -d $MAINDIR/tmp ] || mkdir $MAINDIR/tmp
 DATE=$(date +%I:%M%p)
 CHECK="\\033[1;32m✔\\033[0;39m"


### PR DESCRIPTION
J'ai essayé d'installer le projet en local et j'avais l'erreur suivante lors du `./bin/assets.sh`

`ERROR: Can't find config file: aperophp/vendor/twitter/bootstrap/js/.jshintrc`

J'ai donc corrigé le fichier assets.sh en remplaçant twitter par twbs. Changement fait ici : https://github.com/afup/aperophp/pull/122