### PR TITLE
Affichage du menu "Statistique", qu'on soit connecté ou pas

### DIFF
--- a/src/Resources/views/common/topbar.html.twig
+++ b/src/Resources/views/common/topbar.html.twig
@@ -29,22 +29,22 @@
                     </a>
                 </li>
                 {% if not(app.session.has('member')) %}
-                <li{% if app.session.get('menu') == 'signup' %} class="active"{% endif %}>
-                    <a href="{{ url('_signupmember') }}">
-                        <i class="icon-signin"></i> <span>S'inscrire</span>
-                    </a>
-                </li>
-                <li{% if app.session.get('menu') == 'signin' %} class="active"{% endif %}>
-                    <a href="{{ url('_signinmember') }}">
-                        <i class="icon-key"></i> <span>Se connecter</span>
-                    </a>
-                </li>
+                    <li{% if app.session.get('menu') == 'signup' %} class="active"{% endif %}>
+                        <a href="{{ url('_signupmember') }}">
+                            <i class="icon-signin"></i> <span>S'inscrire</span>
+                        </a>
+                    </li>
+                    <li{% if app.session.get('menu') == 'signin' %} class="active"{% endif %}>
+                        <a href="{{ url('_signinmember') }}">
+                            <i class="icon-key"></i> <span>Se connecter</span>
+                        </a>
+                    </li>
+                {% endif %}
                 <li{% if app.session.get('menu') == 'stats' %} class="active"{% endif %}>
                     <a href="{{ url('_stats', {'type': 'year', 'city': 0}) }}">
                         <i class="icon-signal"></i> <span>Statistiques</span>
                     </a>
                 </li>
-                {% endif %}
             </ul>
         </div> <!-- /container -->
     </div> <!-- /subnavbar-inner -->


### PR DESCRIPTION
# Quoi
Le menu "Statistique" n'était affiché que lorsque l'utilisateur n'était pas connecté

# Pourquoi
A cause d'une absence d'indentation, il n'était pas clair que cet item était dans la liste de ceux conditionné à la non-connexion.
Du coup, le menu "Statistique" est maintenant plus conditionné à la connexion et l'indentation est maintenant claire
