### PR TITLE
augmentation de la limite du nombre d'apéros affichés sur la home

### DIFF
--- a/src/Aperophp/Provider/Controller/Drink.php
+++ b/src/Aperophp/Provider/Controller/Drink.php
@@ -23,7 +23,7 @@ class Drink implements ControllerProviderInterface
         {
             $app['session']->set('menu', 'home');
 
-            $drinks = $app['drinks']->findNext(10);
+            $drinks = $app['drinks']->findNext(12);
 
             return $app['twig']->render('drink/index.html.twig', array(
                 'drinks' => $drinks


### PR DESCRIPTION
Nous ne voyons pas tous les apéros du super apéro PHP sur la home
de aperophp.net

Afin de tous les voir, on augmente la limite.